### PR TITLE
CI with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,82 @@
+on: 
+    pull_request:
+      branches: [ main ]
+    push:
+      branches: [ main ]
+name: ci/github
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.17.x]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Check out code
+      uses: actions/checkout@v2
+    - name: Unit Test
+      run: make test
+    - name: Integration Test
+      run: make test-integration
+  e2e:
+    strategy:
+      matrix:
+        kubernetes: [v1.21.2]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17.x
+    - name: Check out code
+      uses: actions/checkout@v2
+    - name: Install kubectl
+      uses: azure/setup-kubectl@v1
+      with:
+        version: ${{ matrix.kubernetes }}
+    - name: Install Ko
+      # This sha corresponds to v0.4
+      uses: imjasonh/setup-ko@2c3450ca27f6e6f2b02e72a40f2163c281a1f675
+      with:
+        version: v0.11.2
+    - name: Create kind cluster
+      uses: helm/kind-action@v1.2.0
+      with:
+        version: v0.11.1
+        node_image: kindest/node:${{ matrix.kubernetes }}
+        cluster_name: kind
+        config: test/e2e/testdata/kind.yaml
+        wait: 120s
+    - name: Verify kind cluster
+      run: |
+        echo "# Using KinD context..."
+        kubectl config use-context "kind-kind"
+        echo "# KinD nodes:"
+        kubectl get nodes
+
+        NODE_STATUS=$(kubectl get node kind-control-plane -o json | jq -r .'status.conditions[] | select(.type == "Ready") | .status')
+        if [ "${NODE_STATUS}" != "True" ]; then
+          echo "# Node is not ready:"
+          kubectl describe node kind-control-plane
+
+          echo "# Pods:"
+          kubectl get pod -A
+          echo "# Events:"
+          kubectl get events -A
+
+          exit 1
+        fi
+    - name: Install cert-manager
+      run: kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.8.0/cert-manager.yaml
+    - name: Deploy
+      run: make deploy KO=/usr/local/bin/ko IMAGE_REPO=kind.local
+    - name: Test
+      run: make test-e2e

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,12 @@
 
 ## Building
 
+### Golang
+
+This project assumes you have golang 1.17 or higher installed on your machine.
+
+### Container Image
+
 This project uses [ko](https://github.com/google/ko) to build the container image with the
 controller manager and deploy it to a Kubernetes cluster. To change the destination container
 registry, provide the `IMAGE_REPO` variable to any make target:
@@ -40,14 +46,17 @@ By default the following arguments are passed to ko:
 
 - Ensure unit tests pass by running `make test`.
 - Ensure integration tests pass by running `make test-integration`.
+- Ensure that [cert-manager](https://cert-manager.io) has been installed on your cluster.
 - Ensure that you are able to build and deploy the controller image to your Kubernetes cluster:
 
-```sh
-$ make deploy IMAGE_REPO=quay.io/myusername
-```
+   ```sh
+   $ make deploy IMAGE_REPO=quay.io/myusername
+   ```
 
-*Note*: This will publish the container image to `quay.io/myusername/project:latest`. For the
-deployment to succeed, your cluster must have permission to pull this image.
+   *Note*: This will publish the container image to `quay.io/myusername/project:latest`. For the
+   deployment to succeed, your cluster must have permission to pull this image.
+
+- Optionally, ensure end to end tests succeed by running `make test-e2e`.
 
 ### KinD
 
@@ -56,6 +65,8 @@ TODO: Provide instructions on how to deploy with KinD
 ### CodeReady Containers
 
 To deploy on an OpenShift CodeReady Containers cluster, do the following:
+
+0. Install the cert-manager operator from OperatorHub.
 
 1. Create a project for the deployment (project-system by default)
 

--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,15 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet ## Run unit tests.
-	go test ./... -coverprofile unit.out
+	go test . ./api/... ./controllers/... ./pkg/... -coverprofile unit.out
 
 .PHONY: test-integration
 test-integration: manifests generate fmt vet envtest ## Run integration tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./test/integration/... -coverprofile integration.out -tags integration
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./test/integration/... -coverprofile integration.out
+
+.PHONY: test-e2e
+test-e2e:
+	KUBECONFIG=${KUBECONFIG} go test -v ./test/e2e/...
 
 ##@ Build
 

--- a/test/e2e/framework/deployment.go
+++ b/test/e2e/framework/deployment.go
@@ -1,0 +1,24 @@
+package framework
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func IsDeploymentReady(ctx context.Context, c client.Client) (bool, error) {
+	deployment := &appsv1.Deployment{}
+	err := c.Get(ctx, client.ObjectKey{Namespace: "project-system", Name: "project-controller-manager"}, deployment)
+	if err != nil {
+		return false, err
+	}
+	for _, condition := range deployment.Status.Conditions {
+		if condition.Type != appsv1.DeploymentAvailable {
+			continue
+		}
+		return condition.Status == corev1.ConditionTrue, nil
+	}
+	return false, nil
+}

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -1,0 +1,67 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	batchv1 "tutorial.kubebuilder.io/project/api/v1"
+	"tutorial.kubebuilder.io/project/test/e2e/framework"
+)
+
+var (
+	kubeClient  client.Client
+	testContext context.Context
+	cancel      context.CancelFunc
+)
+
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "E2E Suite")
+}
+
+var _ = BeforeSuite(func() {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(batchv1.AddToScheme(scheme))
+
+	rest, err := ctrl.GetConfig()
+	Expect(err).NotTo(HaveOccurred())
+
+	kubeClient, err = client.New(rest, client.Options{
+		Scheme: scheme,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	testContext, cancel = context.WithCancel(context.Background())
+})
+
+var _ = BeforeEach(func() {
+	By("waiting for project deployment")
+	err := wait.PollImmediate(10*time.Second, 5*time.Minute, func() (bool, error) {
+		return framework.IsDeploymentReady(testContext, kubeClient)
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+})
+
+var _ = When("the controller has been deployed", func() {
+	It("should be ready", func() {
+		ready, err := framework.IsDeploymentReady(testContext, kubeClient)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ready).To(BeTrue())
+	})
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+})

--- a/test/e2e/testdata/kind.yaml
+++ b/test/e2e/testdata/kind.yaml
@@ -1,0 +1,14 @@
+# Note - this configuration file can live in a shared repository
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 32222
+    hostPort: 32222
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      extraArgs:
+        enable-admission-plugins: CertificateApproval,CertificateSigning,CertificateSubjectRestriction,DefaultIngressClass,DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,NodeRestriction,OwnerReferencesPermissionEnforcement,PersistentVolumeClaimResize,PersistentVolumeLabel,PodNodeSelector,PodTolerationRestriction,Priority,ResourceQuota,RuntimeClass,ServiceAccount,StorageObjectInUseProtection,TaintNodesByCondition,ValidatingAdmissionWebhook

--- a/test/integration/controllers/cronjob_controller_test.go
+++ b/test/integration/controllers/cronjob_controller_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 /*
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/integration/controllers/suite_test.go
+++ b/test/integration/controllers/suite_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 /*
 Copyright 2022 The Kubernetes authors.
 


### PR DESCRIPTION
- Add job for unit/integration testing
- Add configuration to deploy KinD and scaffold an e2e test
- Use github action to install ko
- Add e2e test scaffold with ginkgo
- Drop use of build constraints/tags